### PR TITLE
Get rid of the osc dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Configuration file
 Here is a sample configuration file:
 
 ```yaml
-api: https://api.opensuse.org
+url: https://download.opensuse.org
 group: suse
 repositories:
   Leap:
@@ -42,7 +42,7 @@ artifacts:
     repository: Leap
 ```
 
-The `apiurl` property is optional and defaults to `https://api.opensuse.org`, but can be used to get packages from another OpenBuildService instance.
+The `url` property is optional and defaults to `https://download.opensuse.org`, but can be used to get packages from another download site.
 
 The `repositories` key contains a dictionary of repository definitions.
 The name of those repositories is used in the artifacts.

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ The properties of each artifact help locating the RPM and jar files in OBS. The 
 
 Since there is no silver bullet to find the RPM or the JAR file in it, there are some additional optional properties to provide hints:
 
-* `package`: the name of the package in OBS. Note that this is different from the RPM name. By default, the artifact name is used.
+* `package`: the name of the package in OBS. Note that this is different from the RPM name. By default, the artifact name is used and the `demo`, `test`, `manual`, `examples` and `javadoc` rpms are discarded. If the pattern includes the version match, terminate it with `-` to avoid the `-[0-9]` pattern to be appended.
 * `arch`: defaults to `noarch`, but this may need to be overriden in some cases.
-* `rpm`: a regular expression to match the file name of the RPM. By default the `demo`, `test`, `manual`, `examples` and `javadoc` rpms are discarded.
+* `rpm`: a regular expression to match the file name of the RPM **deprecated**
 * `jar`: a regular expression to match the non symlinked jar base name.
 
 As a maven repository needs a group ID for each artifact, this can be configured at several levels.

--- a/obs-to-maven
+++ b/obs-to-maven
@@ -100,7 +100,7 @@ class Artifact:
         self.arch = config.get('arch', 'noarch')
         self.repository = repositories.get(config['repository'])
         if not self.repository:
-            logging.error('Missing repository definition: %s', config['repository'])
+            raise RuntimeError('Missing repository definition: ' + config['repository'])
         self.rpm = config.get('rpm')
         self.jar = config.get('jar')
 
@@ -114,12 +114,11 @@ class Artifact:
         ]
 
         if len(filtered) > 1:
-            logging.warning('Found more than one file for %s:\n  %s' %
-                    (self.artifact, "\n  ".join([file.name for file in filtered])))
+            raise RuntimeError('Found more than one file for {}:\n  {}'.format(
+                self.artifact, "\n  ".join([file.name for file in filtered])))
 
         if len(filtered) == 0:
-            logging.error('Found no file for %s' % (self.artifact))
-            return None
+            raise RuntimeError('Found no file for ' + self.artifact)
         return filtered[0]
 
     def fetch_binary(self, file, tmp):
@@ -153,9 +152,10 @@ class Artifact:
         to_extract = [f for f in not_linked if re.match(full_pattern, f)]
 
         if len(to_extract) == 0:
-            logging.error('Found no jar to extract in %s' % rpm_file)
+            raise RuntimeError('Found no jar to extract in ' + rpm_file)
         elif len(to_extract) > 1:
-            logging.warning('Found several jars to extract in %s:\n  %s' % (rpm_file, '\n  '.join(to_extract)))
+            raise RuntimeError('Found several jars to extract in {}:\n  {}'.format(
+                rpm_file, '\n  '.join(to_extract)))
 
         jar_entry = to_extract[0]
 
@@ -257,13 +257,12 @@ class Artifact:
             logging.debug('package mtime: %d, [%s]' % (file.mtime, ', '.join(['%f' % t for t in mtimes])))
             rpm_file = self.fetch_binary(file, tmp)
             if rpm_file is None:
-                logging.error('Failed to download %s' % file)
-                return
+                raise RuntimeError('Failed to download ' + file)
 
             # Find out the version
-            m = re.match('.*-([^-]+)-[^-]+.%s.rpm' % self.arch, rpm_file)
+            m = re.match('.*-([^-]+)-[^-]+.[^.]+.rpm', rpm_file)
             if m is None:
-                logging.error('Failed to get version of %s' % rpm_file)
+                raise RuntimeError('Failed to get version of ' + rpm_file)
             version = m.group(1)
 
             # Extract the jar and pom
@@ -294,6 +293,7 @@ class Configuration:
         self.artifacts = [Artifact(artifact, repos, data.get('group', 'suse')) for artifact in data.get('artifacts', [])]
 
 def main():
+    ret = 0
     parser = argparse.ArgumentParser(
         description="OBS to Maven repository synchronization tool",
         conflict_handler='resolve',
@@ -316,9 +316,14 @@ def main():
     logging.debug('Reading configuration')
     config = Configuration(args.config, args.out)
     tmp = tempfile.mkdtemp(prefix="obsmvn-")
-    for artifact in config.artifacts:
-        artifact.process(config.repo, tmp)
+    try:
+        for artifact in config.artifacts:
+            artifact.process(config.repo, tmp)
+    except RuntimeError as e:
+        logging.error(e)
+        ret = 1
     shutil.rmtree(tmp)
+    return ret
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/obs-to-maven
+++ b/obs-to-maven
@@ -283,11 +283,11 @@ class Configuration:
             f = open(config_path, 'r')
             data = yaml.safe_load(f)
             f.close()
-        self.api = data.get('api', "https://download.opensuse.org")
+        self.url = data.get('url', "https://download.opensuse.org")
         self.repo = repo
         repositories = data.get('repositories', {})
         repos = {
-            name: Repo(self.api, data['project'], data['repository'])
+            name: Repo(self.url, data['project'], data['repository'])
             for name, data
             in repositories.items()
         }

--- a/obs-to-maven
+++ b/obs-to-maven
@@ -96,21 +96,23 @@ class Artifact:
     def __init__(self, config, repositories, group):
         self.artifact = config['artifact']
         self.group = config.get('group', group)
-        self.package = config.get('package', self.artifact)
+        self.package = config.get('rpm') or config.get('package', self.artifact)
+        if config.get('rpm'):
+            logging.warning('artifact "rpm" property is deprecated')
         self.arch = config.get('arch', 'noarch')
         self.repository = repositories.get(config['repository'])
         if not self.repository:
             raise RuntimeError('Missing repository definition: ' + config['repository'])
-        self.rpm = config.get('rpm')
         self.jar = config.get('jar')
 
     def get_binary(self):
+        file_pattern = self.package if self.package.endswith("-") else self.package + "-[0-9]"
         excluded = ['javadoc', 'examples', 'manual', 'test', 'demo']
         filtered = [
             file
             for file in self.repository.rpms
             if not bool([pattern for pattern in excluded if pattern in file.name]) and
-                re.match(self.rpm or self.package + "-[0-9]", file.name)
+                re.match(file_pattern, file.name)
         ]
 
         if len(filtered) > 1:
@@ -118,7 +120,7 @@ class Artifact:
                 self.artifact, "\n  ".join([file.name for file in filtered])))
 
         if len(filtered) == 0:
-            raise RuntimeError('Found no file for ' + self.artifact)
+            raise RuntimeError('Found no file matching "{}" for {}'.format(file_pattern, self.artifact))
         return filtered[0]
 
     def fetch_binary(self, file, tmp):

--- a/obs-to-maven
+++ b/obs-to-maven
@@ -27,11 +27,10 @@ import shutil
 import sys
 import subprocess
 import tempfile
+import urllib.request
 import xml.etree.ElementTree as ET
 import yaml
-
-import osc.core
-import osc.conf
+import zlib
 
 def make_str(s):
     if sys.version_info[0] < 3 and isinstance(s, unicode):
@@ -40,40 +39,93 @@ def make_str(s):
         s = s.decode('utf-8')
     return s
 
+class Rpm:
+    def __init__(self, location, mtime):
+        self.path = location
+        self.mtime = mtime
+        self.name = location[location.find('/') + 1:]
+
+class Repo:
+    def __init__(self, uri, project, repository):
+        self.uri = uri
+        self.project = project
+        self.repository = repository
+        self._rpms = None
+
+    def find_primary(self):
+        ns = {'repo': 'http://linux.duke.edu/metadata/repo', 'rpm': 'http://linux.duke.edu/metadata/rpm'}
+        f = urllib.request.urlopen(
+            "{}/repositories/{}/{}/repodata/repomd.xml".format(self.uri, self.project, self.repository)
+        )
+        doc = ET.fromstring(f.read())
+        primary_href = doc.find("./repo:data[@type='primary']/repo:location", ns).get("href")
+        return "{}/repositories/{}/{}/{}".format(self.uri, self.project, self.repository, primary_href)
+
+    def parse_primary(self):
+        ns = {"c": "http://linux.duke.edu/metadata/common", "rpm":"http://linux.duke.edu/metadata/rpm"}
+        f = urllib.request.urlopen(self.find_primary())
+        primary_xml = zlib.decompress(f.read(), 16 + zlib.MAX_WBITS)
+        doc = ET.fromstring(primary_xml)
+
+        self._rpms = [
+            Rpm(n.find("c:location", ns).get("href"), int(n.find("c:time", ns).get("file")))
+            for n
+            in doc.findall(".//c:package", ns)
+            if n.find("c:arch", ns).text in ["x86_64", "noarch"]
+        ]
+
+    @property
+    def rpms(self):
+        if not self._rpms:
+            self.parse_primary()
+        return self._rpms
+
+    def get_binary(self, path, target, mtime):
+        """
+        Equivalent of osc.core.get_binary_file
+        """
+        f = urllib.request.urlopen("{}/repositories/{}/{}/{}".format(self.uri, self.project, self.repository, path))
+        target_f = open(target, 'wb')
+        shutil.copyfileobj(f, target_f)
+        target_f.close()
+        f.close()
+        os.utime(target, (mtime, mtime))
+
+
 class Artifact:
     def __init__(self, config, repositories, group):
         self.artifact = config['artifact']
         self.group = config.get('group', group)
         self.package = config.get('package', self.artifact)
         self.arch = config.get('arch', 'noarch')
-        repository = repositories.get(config['repository'], {})
-        self.project = repository['project']
-        self.repository = repository['repository']
+        self.repository = repositories.get(config['repository'])
+        if not self.repository:
+            logging.error('Missing repository definition: %s', config['repository'])
         self.rpm = config.get('rpm')
         self.jar = config.get('jar')
 
-    def get_binary(self, api):
-        binaries = osc.core.get_binarylist(api, self.project, self.repository, 'x86_64', self.package, True)
+    def get_binary(self):
         excluded = ['javadoc', 'examples', 'manual', 'test', 'demo']
-        filtered = [file for file in binaries
-                    if file.name.endswith('.%s.rpm' % self.arch) and
-                    not bool([pattern for pattern in excluded if pattern in file.name]) and
-                    re.match(self.rpm if self.rpm is not None else '', file.name)]
+        filtered = [
+            file
+            for file in self.repository.rpms
+            if not bool([pattern for pattern in excluded if pattern in file.name]) and
+                re.match(self.rpm or self.package + "-[0-9]", file.name)
+        ]
 
         if len(filtered) > 1:
             logging.warning('Found more than one file for %s:\n  %s' %
                     (self.artifact, "\n  ".join([file.name for file in filtered])))
 
         if len(filtered) == 0:
-            logging.error('Found no file for %s among:\n  %s' % (self.artifact, '\n  '.join([f.name for f in binaries])))
+            logging.error('Found no file for %s' % (self.artifact))
             return None
         return filtered[0]
 
-    def fetch_binary(self, api, file, tmp):
+    def fetch_binary(self, file, tmp):
         target_file = os.path.join(tmp, file.name)
         logging.info('Downloading %s' % target_file)
-        osc.core.get_binary_file(api, self.project, self.repository, 'x86_64', file.name, self.package,
-                                 target_file, file.mtime)
+        self.repository.get_binary(file.path, target_file, file.mtime)
         if os.path.isfile(target_file):
             return target_file
         return None
@@ -190,9 +242,9 @@ class Artifact:
                 fd.write(xml)
 
 
-    def process(self, api, repo, tmp):
+    def process(self, repo, tmp):
         logging.info('Processing artifact %s' % self.artifact)
-        file = self.get_binary(api)
+        file = self.get_binary()
 
         # Check if one of the artifact's jar has the same mtime. If so no need to update
         mtimes = [y for x in [
@@ -203,7 +255,7 @@ class Artifact:
 
         if not [mtime for mtime in mtimes if file.mtime == int(mtime)]:
             logging.debug('package mtime: %d, [%s]' % (file.mtime, ', '.join(['%f' % t for t in mtimes])))
-            rpm_file = self.fetch_binary(api, file, tmp)
+            rpm_file = self.fetch_binary(file, tmp)
             if rpm_file is None:
                 logging.error('Failed to download %s' % file)
                 return
@@ -230,13 +282,16 @@ class Configuration:
             f = open(config_path, 'r')
             data = yaml.safe_load(f)
             f.close()
-        self.api = data.get('api', osc.conf.DEFAULTS['apiurl'])
+        self.api = data.get('api', "https://download.opensuse.org")
         self.repo = repo
         repositories = data.get('repositories', {})
-        self.artifacts = [Artifact(artifact, repositories, data.get('group', 'suse')) for artifact in data.get('artifacts', [])]
+        repos = {
+            name: Repo(self.api, data['project'], data['repository'])
+            for name, data
+            in repositories.items()
+        }
 
-        # Load OSC configuration, setup HTTP authentication
-        osc.conf.get_config(override_apiurl=self.api)
+        self.artifacts = [Artifact(artifact, repos, data.get('group', 'suse')) for artifact in data.get('artifacts', [])]
 
 def main():
     parser = argparse.ArgumentParser(
@@ -262,7 +317,7 @@ def main():
     config = Configuration(args.config, args.out)
     tmp = tempfile.mkdtemp(prefix="obsmvn-")
     for artifact in config.artifacts:
-        artifact.process(config.api, config.repo, tmp)
+        artifact.process(config.repo, tmp)
     shutil.rmtree(tmp)
 
 if __name__ == '__main__':

--- a/obs-to-maven
+++ b/obs-to-maven
@@ -145,21 +145,25 @@ class Artifact:
 
         logging.debug('not linked:\n  %s' % '\n  '.join(not_linked))
 
-        pattern = self.jar if self.jar is not None else ''
+        pattern = self.jar if self.jar is not None else self.artifact
         end_pattern = '[^/]*\.jar' if self.jar is None or not self.jar.endswith('.jar') else ''
         full_pattern = '^/usr/share/.*/%s%s$' % (pattern, end_pattern)
 
         logging.debug('full pattern: %s' % full_pattern)
 
-        to_extract = [f for f in not_linked if re.match(full_pattern, f)]
-
-        if len(to_extract) == 0:
+        jars = [f for f in not_linked if re.match('^/usr/share/.*/{}'.format(end_pattern), f)]
+        if len(jars) == 0:
             raise RuntimeError('Found no jar to extract in ' + rpm_file)
-        elif len(to_extract) > 1:
-            raise RuntimeError('Found several jars to extract in {}:\n  {}'.format(
-                rpm_file, '\n  '.join(to_extract)))
-
-        jar_entry = to_extract[0]
+        elif len(jars) > 1:
+            to_extract = [f for f in jars if re.match(full_pattern, f)]
+            if len(to_extract) == 0:
+                raise RuntimeError('Found no jar matching {} in {}'.format(pattern, rpm_file))
+            elif len(to_extract) > 1:
+                raise RuntimeError('Found several jars to extract in {}:\n  {}'.format(
+                    rpm_file, '\n  '.join(to_extract)))
+            jar_entry = to_extract[0]
+        else:
+            jar_entry = jars[0]
 
         # try harder to guess the version number from the jar file since it may be different from the rpm
         matcher = re.search('%s-([0-9.]+).jar' % self.artifact, os.path.basename(jar_entry))


### PR DESCRIPTION
The reason for not relying on osc is that it requires OBS credentials.
These are painfull to handle in the CI and for the newcomers. The new
implementation only uses the download pages.