### PR TITLE
Don't store the parser handler data in class members

### DIFF
--- a/obs_maven/primary_handler.py
+++ b/obs_maven/primary_handler.py
@@ -28,9 +28,11 @@ class Handler(xml.sax.handler.ContentHandler):
     SAX parser handler for repository primary.xml files.
     """
 
-    package = None
-    rpms = {}
-    text = None
+    def __init__(self):
+        super().__init__()
+        self.package = None
+        self.rpms = {}
+        self.text = None
 
     def startElementNS(self, name, qname, attrs):
         searched_attrs = {

--- a/obs_maven/repo.py
+++ b/obs_maven/repo.py
@@ -25,7 +25,6 @@ from xml.sax.xmlreader import InputSource
 import zlib
 
 import obs_maven.primary_handler
-from obs_maven.rpm import Rpm
 
 
 class Repo:


### PR DESCRIPTION
We learn a language every day. After many years using python I only
discovered that variables defined outside of the `__init__()` are class
members... and that made the parser data passed after each use.