### PR TITLE
Download primary to disk first

### DIFF
--- a/obs_maven/repo.py
+++ b/obs_maven/repo.py
@@ -60,6 +60,7 @@ class Repo:
         logging.debug("Parsing primary %s", primary_url)
         for cnt in range(1, 4):
             try:
+                logging.debug("Getting primary try %s", cnt)
 
                 # Download the primary.xml.gz to a file first to avoid
                 # connection resets
@@ -82,9 +83,9 @@ class Repo:
                         input_source.setByteStream(gzip_fd)
                         parser.parse(input_source)
                         self._rpms = handler.rpms.values()
-            except:
+                break
+            except OSError:
                 if cnt < 3:
-                    logging.debug("Getting primary try {}".format(cnt + 1))
                     time.sleep(2)
                 else:
                     raise

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="obs-to-maven",
-    version="1.1.3",
+    version="1.1.4",
     author="Cedric Bosdonnat",
     author_email="cedric.bosdonnat@suse.com",
     description="Tool extracting jars from RPMs in OpenBuildService to a maven repo",


### PR DESCRIPTION
We see a lot of ConnectionResetErrors in our JenkinsCI. I hope that downloading the whole compressed file first will help with that, based on the assumption that the server resets the connection when the current stream-based parsing takes too long.

We will still decompress the file as we parse without reading it into memory to keep the memory footprint low.

~~I want to double check that `for line in primary_fd:` work as expected, it might not since the document is compressed.~~