### PR TITLE
Fix version compare

### DIFF
--- a/obs_maven/primary_handler.py
+++ b/obs_maven/primary_handler.py
@@ -73,7 +73,7 @@ class Handler(xml.sax.handler.ContentHandler):
                 )
 
                 latest_rpm = self.rpms.get(pkg_name)
-                if latest_rpm is None or latest_rpm.compare(rpm):
+                if latest_rpm is None or latest_rpm.compare(rpm) >= 1:
                     self.rpms[pkg_name] = rpm
         elif self.package is not None and name[0] == COMMON_NS and name[1] in SEARCHED_CHARS:
             self.package[name[1]] = self.text

--- a/obs_maven/rpm.py
+++ b/obs_maven/rpm.py
@@ -97,6 +97,9 @@ class Rpm:
         self.version = version
         self.release = release
 
+    def __str__(self):
+        return "<Rpm {}: {}:{}-{}>".format(self.pkgname, self.epoch or 0, self.version, self.release)
+
     def compare(self, other):
         return _compare_rpm_labels(
             (other.epoch, other.version, other.release), (self.epoch, self.version, self.release)


### PR DESCRIPTION
The version compare of RPMs is wrong as when compare return -1, it is treated as higher as well.